### PR TITLE
Make Rack::Middleware delegate to a proc for enabling tracing

### DIFF
--- a/lib/hubstep.rb
+++ b/lib/hubstep.rb
@@ -7,14 +7,6 @@ require "socket"
 
 #:nodoc:
 module HubStep
-  def self.tracing_enabled=(value)
-    @tracing_enabled = value
-  end
-
-  def self.tracing_enabled?
-    !!@tracing_enabled
-  end
-
   def self.hostname
     @hostname ||= Socket.gethostname.freeze
   end

--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -6,14 +6,14 @@ module HubStep
   module Rack
     # Rack middleware for wrapping a request in a span.
     class Middleware
-      def initialize(app, tracer, enabled_block)
+      def initialize(app, tracer, enabled_proc)
         @app = app
         @tracer = tracer
-        @enabled_block = enabled_block
+        @enabled_proc = enabled_proc
       end
 
       def call(env)
-        @tracer.with_enabled(@enabled_block.call(env)) do
+        @tracer.with_enabled(@enabled_proc.call(env)) do
           trace(env) do
             @app.call(env)
           end

--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -6,13 +6,14 @@ module HubStep
   module Rack
     # Rack middleware for wrapping a request in a span.
     class Middleware
-      def initialize(app, tracer)
+      def initialize(app, tracer, enabled_block)
         @app = app
         @tracer = tracer
+        @enabled_block = enabled_block
       end
 
       def call(env)
-        @tracer.with_enabled(HubStep.tracing_enabled?) do
+        @tracer.with_enabled(@enabled_block.call(env)) do
           trace(env) do
             @app.call(env)
           end

--- a/test/hubstep/rack/middleware_test.rb
+++ b/test/hubstep/rack/middleware_test.rb
@@ -14,12 +14,6 @@ module HubStep
       def setup
         @block = ->(_env) { [200, {}, "<html>"] }
         @enabled_block = ->(_env) { true }
-        @original_enabled = HubStep.tracing_enabled?
-        HubStep.tracing_enabled = true
-      end
-
-      def teardown
-        HubStep.tracing_enabled = @original_enabled
       end
 
       def tracer

--- a/test/hubstep/rack/middleware_test.rb
+++ b/test/hubstep/rack/middleware_test.rb
@@ -25,6 +25,16 @@ module HubStep
         @tracer ||= Tracer.new
       end
 
+      def test_requires_a_tracer
+        app = ::Rack::Builder.new do
+          use HubStep::Rack::Middleware
+          run ->(_env) { [200, {}, "<html>"] }
+        end
+        assert_raises ArgumentError do
+          app.to_app
+        end
+      end
+
       def test_wraps_request_in_span
         top_span = nil
         @block = lambda do |_env|

--- a/test/hubstep/rack/middleware_test.rb
+++ b/test/hubstep/rack/middleware_test.rb
@@ -9,10 +9,11 @@ module HubStep
     class MiddlewareTest < Minitest::Test
       include ::Rack::Test::Methods
 
-      attr_reader :block
+      attr_reader :block, :enabled_block
 
       def setup
         @block = ->(_env) { [200, {}, "<html>"] }
+        @enabled_block = ->(_env) { true }
         @original_enabled = HubStep.tracing_enabled?
         HubStep.tracing_enabled = true
       end
@@ -33,6 +34,59 @@ module HubStep
         assert_raises ArgumentError do
           app.to_app
         end
+      end
+
+      def test_requires_an_enabled_block
+        app = ::Rack::Builder.new do
+          use HubStep::Rack::Middleware, HubStep::Tracer.new
+          run ->(_env) { [200, {}, "<html>"] }
+        end
+        assert_raises ArgumentError do
+          app.to_app
+        end
+      end
+
+      def test_passes_env_to_enabled_block
+        passed_env = nil
+        @enabled_block = lambda do |env|
+          passed_env = env
+          true
+        end
+
+        get "/foo"
+
+        assert_kind_of Hash, passed_env
+        assert_equal "/foo", passed_env["PATH_INFO"]
+      end
+
+      def test_enables_tracing_during_request_if_specified
+        tracer.enabled = false
+        enabled_in_request = nil
+        @block = lambda do |_env|
+          enabled_in_request = tracer.enabled?
+          [200, {}, "<html>"]
+        end
+        @enabled_block = ->(_env) { true }
+
+        get "/foo"
+
+        assert enabled_in_request
+        refute tracer.enabled?
+      end
+
+      def test_disables_tracing_during_request_if_specified
+        tracer.enabled = true
+        enabled_in_request = nil
+        @block = lambda do |_env|
+          enabled_in_request = tracer.enabled?
+          [200, {}, "<html>"]
+        end
+        @enabled_block = ->(_env) { false }
+
+        get "/foo"
+
+        assert_equal false, enabled_in_request
+        assert tracer.enabled?
       end
 
       def test_wraps_request_in_span
@@ -71,7 +125,7 @@ module HubStep
       def app
         test_instance = self
         @app ||= ::Rack::Builder.new do
-          use HubStep::Rack::Middleware, test_instance.tracer
+          use HubStep::Rack::Middleware, test_instance.tracer, test_instance.enabled_block
           run ->(env) { test_instance.block.call(env) }
         end
       end


### PR DESCRIPTION
This lets users enable tracing for individual requests as desired. And it lets us get rid of `HubStep.tracing_enabled?` which was kinda yucky global state.