### PR TITLE
Improve name/tags of spans for Rack requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,5 +37,8 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
   ConsistentQuotesInMultiline: true
 
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma

--- a/hubstep.gemspec
+++ b/hubstep.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test", "~> 0.6"
   spec.add_development_dependency "activesupport", "~> 4.0"
   spec.add_development_dependency "faraday", "~> 0.10"
+  spec.add_development_dependency "pry-byebug"
 end

--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -23,7 +23,7 @@ module HubStep
       private
 
       def trace(env)
-        @tracer.span("request") do |span|
+        @tracer.span("Rack #{env["REQUEST_METHOD"]}") do |span|
           span.configure do
             add_tags(span, ::Rack::Request.new(env))
           end
@@ -44,6 +44,7 @@ module HubStep
 
       def tags(request)
         tags = {
+          "component" => "rack",
           "span.kind" => "server",
           "http.url" => request.url,
           "http.method" => request.request_method,

--- a/test/hubstep/rack/middleware_test.rb
+++ b/test/hubstep/rack/middleware_test.rb
@@ -83,7 +83,7 @@ module HubStep
         assert tracer.enabled?
       end
 
-      def test_wraps_request_in_span
+      def test_wraps_request_in_span # rubocop:disable Metrics/MethodLength
         top_span = nil
         @request_proc = lambda do |_env|
           top_span = tracer.top_span
@@ -93,13 +93,14 @@ module HubStep
         get "/foo"
 
         expected = {
+          "component" => "rack",
           "http.method" => "GET",
           "http.status_code" => "302",
           "http.url" => "http://example.org/foo",
           "span.kind" => "server",
         }
 
-        assert_equal "request", top_span.operation_name
+        assert_equal "Rack GET", top_span.operation_name
         assert_equal expected, top_span.tags.select { |key, _value| expected.key?(key) }
         refute_includes top_span.tags, "guid:github_request_id"
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,4 +2,5 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "hubstep"
 
+require "pry-byebug"
 require "minitest/autorun"


### PR DESCRIPTION
It's now clearer that the span originated in Rack, and the name includes the request method. I considering including the path info as well but the cardinality of that is likely far too high in many apps.