### PR TITLE
Rename and generalize TracingInstrumenter

### DIFF
--- a/lib/hubstep/instrumenter.rb
+++ b/lib/hubstep/instrumenter.rb
@@ -5,7 +5,7 @@ require "active_support/notifications"
 module HubStep
   # Wrapper around ActiveSupport::Notifications that traces instrumented
   # blocks.
-  class TracingInstrumenter
+  class Instrumenter
     def initialize(tracer)
       @tracer = tracer
     end

--- a/lib/hubstep/instrumenter.rb
+++ b/lib/hubstep/instrumenter.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
-require "active_support/notifications"
-
 module HubStep
   # Wrapper around ActiveSupport::Notifications that traces instrumented
   # blocks.
   class Instrumenter
-    def initialize(tracer)
+    # Creates an Instrumenter
+    #
+    # tracer  - HubStep::Tracer instance
+    # service - Object that provides ActiveSupport::Notifications' API (i.e.,
+    #           you could just pass ActiveSupport::Notifications here, or wrap
+    #           it in some other object).
+    def initialize(tracer, service)
       @tracer = tracer
+      @service = service
     end
 
     def publish(name, *args)
@@ -36,8 +41,6 @@ module HubStep
 
     private
 
-    def service
-      ActiveSupport::Notifications
-    end
+    attr_reader :service
   end
 end

--- a/test/hubstep/instrumenter_test.rb
+++ b/test/hubstep/instrumenter_test.rb
@@ -2,13 +2,14 @@
 
 require_relative "../test_helper"
 require "hubstep/instrumenter"
+require "active_support/notifications"
 
 module HubStep
   class InstrumentorTest < Minitest::Test
     def setup
       @tracer = Tracer.new
       @tracer.enabled = true
-      @instrumenter = Instrumenter.new(@tracer)
+      @instrumenter = Instrumenter.new(@tracer, ActiveSupport::Notifications)
     end
 
     def test_traces_instrumented_blocks

--- a/test/hubstep/instrumenter_test.rb
+++ b/test/hubstep/instrumenter_test.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
-require "hubstep/tracing_instrumenter"
+require "hubstep/instrumenter"
 
 module HubStep
-  class TracingInstrumentorTest < Minitest::Test
+  class InstrumentorTest < Minitest::Test
     def setup
       @tracer = Tracer.new
       @tracer.enabled = true
-      @instrumenter = TracingInstrumenter.new(@tracer)
+      @instrumenter = Instrumenter.new(@tracer)
     end
 
     def test_traces_instrumented_blocks


### PR DESCRIPTION
It's now just called `Instrumenter`, and it no longer assumes you want to use `ActiveSupport::Notifications`.