### PR TITLE
Remove Tracer#top_span

### DIFF
--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -6,6 +6,12 @@ module HubStep
   module Rack
     # Rack middleware for wrapping a request in a span.
     class Middleware
+      SPAN = "#{name}.span"
+
+      def self.get_span(env)
+        env[SPAN]
+      end
+
       # Create a Middleware
       #
       # tracer    - a HubStep::Tracer instance
@@ -31,6 +37,8 @@ module HubStep
 
       def trace(env)
         @tracer.span("Rack #{env["REQUEST_METHOD"]}") do |span|
+          env[SPAN] = span
+
           span.configure do
             add_tags(span, ::Rack::Request.new(env))
           end

--- a/lib/hubstep/tracer.rb
+++ b/lib/hubstep/tracer.rb
@@ -47,17 +47,6 @@ module HubStep
       self.enabled = original
     end
 
-    # Get the topmost span in the stack
-    #
-    # This is the span that has no parent span; the rest of the spans in the
-    # stack descend from it.
-    #
-    # Returns a LightStep::Span or InertSpan.
-    def top_span
-      span = @spans.first if enabled?
-      span || InertSpan.instance
-    end
-
     # Get the bottommost span in the stack
     #
     # This is the span that has no children.

--- a/test/hubstep/rack/middleware_test.rb
+++ b/test/hubstep/rack/middleware_test.rb
@@ -117,6 +117,18 @@ module HubStep
         assert_equal "1234abcd", top_span.tags["guid:github_request_id"]
       end
 
+      def test_stores_span_on_env
+        span = nil
+        @request_proc = lambda do |env|
+          span = HubStep::Rack::Middleware.get_span(env)
+          [302, {}, "<html>"]
+        end
+
+        get "/foo"
+
+        assert_equal "Rack GET", span.operation_name
+      end
+
       def app
         test_instance = self
         @app ||= ::Rack::Builder.new do

--- a/test/hubstep/rack/middleware_test.rb
+++ b/test/hubstep/rack/middleware_test.rb
@@ -84,9 +84,9 @@ module HubStep
       end
 
       def test_wraps_request_in_span # rubocop:disable Metrics/MethodLength
-        top_span = nil
+        span = nil
         @request_proc = lambda do |_env|
-          top_span = tracer.top_span
+          span = tracer.bottom_span
           [302, {}, "<html>"]
         end
 
@@ -100,21 +100,21 @@ module HubStep
           "span.kind" => "server",
         }
 
-        assert_equal "Rack GET", top_span.operation_name
-        assert_equal expected, top_span.tags.select { |key, _value| expected.key?(key) }
-        refute_includes top_span.tags, "guid:github_request_id"
+        assert_equal "Rack GET", span.operation_name
+        assert_equal expected, span.tags.select { |key, _value| expected.key?(key) }
+        refute_includes span.tags, "guid:github_request_id"
       end
 
       def test_records_request_id_if_present
-        top_span = nil
+        span = nil
         @request_proc = lambda do |_env|
-          top_span = tracer.top_span
+          span = tracer.bottom_span
           [302, {}, "<html>"]
         end
 
         get "/foo", {}, "HTTP_X_GITHUB_REQUEST_ID" => "1234abcd"
 
-        assert_equal "1234abcd", top_span.tags["guid:github_request_id"]
+        assert_equal "1234abcd", span.tags["guid:github_request_id"]
       end
 
       def test_stores_span_on_env

--- a/test/hubstep/tracer_test.rb
+++ b/test/hubstep/tracer_test.rb
@@ -36,33 +36,6 @@ module HubStep
       assert_predicate tracer, :enabled?
     end
 
-    def test_top_span_returns_inert_instance_when_not_tracing
-      assert_equal HubStep::Tracer::InertSpan.instance, HubStep::Tracer.new.top_span
-    end
-
-    def test_top_span_returns_inert_instance_when_tracing_disabled
-      tracer = HubStep::Tracer.new
-      tracer.enabled = true
-      span = nil
-      tracer.span("foo") do
-        tracer.with_enabled(false) do
-          span = tracer.top_span
-        end
-      end
-      assert_equal HubStep::Tracer::InertSpan.instance, span
-    end
-
-    def test_top_span_returns_top_span_when_tracing
-      tracer = HubStep::Tracer.new
-      tracer.enabled = true
-      tracer.span("foo") do |top_span|
-        assert_equal top_span, tracer.top_span
-        tracer.span("bar") do
-          assert_equal top_span, tracer.top_span
-        end
-      end
-    end
-
     def test_bottom_span_returns_inert_instance_when_not_tracing
       assert_equal HubStep::Tracer::InertSpan.instance, HubStep::Tracer.new.bottom_span
     end


### PR DESCRIPTION
I'd like Tracer's span stack to be an implementation detail. Removing `#top_span` gets us a littler closer to that. It was only being used to fetch `Rack::Middleware`'s span, so now there's a specific API for that: `Rack::Middleware.get_span(env)`.

Hopefully we can remove `#bottom_span` someday. It's currently useful in a few places in Rails apps so I haven't removed it yet.