### PR TITLE
Clean up Rack::Middleware a bit

### DIFF
--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -39,22 +39,24 @@ module HubStep
         @tracer.span("Rack #{env["REQUEST_METHOD"]}") do |span|
           env[SPAN] = span
 
-          span.configure do
-            add_tags(span, ::Rack::Request.new(env))
-          end
+          span.configure { record_request(span, env) }
 
           result = yield
 
-          span.set_tag("http.status_code", result[0])
+          span.configure { record_response(span, *result) }
 
           result
         end
       end
 
-      def add_tags(span, request)
-        tags(request).each do |key, value|
+      def record_request(span, env)
+        tags(::Rack::Request.new(env)).each do |key, value|
           span.set_tag(key, value)
         end
+      end
+
+      def record_response(span, status, _headers, _body)
+        span.set_tag("http.status_code", status)
       end
 
       def tags(request)

--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -45,7 +45,7 @@ module HubStep
 
           result = yield
 
-          span.set_tag("http.status_code", result[0].to_s)
+          span.set_tag("http.status_code", result[0])
 
           result
         end


### PR DESCRIPTION
It now has `#record_request` and `#record_response` methods, similar to `Faraday::Middleware`.

Fixes #12 