### PR TITLE
Rack::Middleware.get_span should never return nil

### DIFF
--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -14,7 +14,7 @@ module HubStep
       #
       # Returns a Span.
       def self.get_span(env)
-        env[SPAN]
+        env[SPAN] || Tracer::InertSpan.instance
       end
 
       # Create a Middleware

--- a/test/hubstep/rack/middleware_test.rb
+++ b/test/hubstep/rack/middleware_test.rb
@@ -129,6 +129,18 @@ module HubStep
         assert_equal "Rack GET", span.operation_name
       end
 
+      def test_get_span_returns_inert_span_when_using_middleware
+        span = nil
+        @app = lambda do |env|
+          span = HubStep::Rack::Middleware.get_span(env)
+          [302, {}, "<html>"]
+        end
+
+        get "/foo"
+
+        assert_kind_of HubStep::Tracer::InertSpan, span
+      end
+
       def app
         test_instance = self
         @app ||= ::Rack::Builder.new do


### PR DESCRIPTION
When the middleware hasn't run yet or isn't in use at all (and thus hasn't stored a span in the request env), we now return an InertSpan so that calling code doesn't have to worry about nil.