### PR TITLE
Include the request body in Failbot needles

### DIFF
--- a/hubstep.gemspec
+++ b/hubstep.gemspec
@@ -31,5 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test", "~> 0.6"
   spec.add_development_dependency "activesupport", "~> 4.0"
   spec.add_development_dependency "faraday", "~> 0.10"
+  spec.add_development_dependency "failbot", "~> 2.0.0"
+  spec.add_development_dependency "webmock", "~> 2.3.1"
   spec.add_development_dependency "pry-byebug"
 end

--- a/test/hubstep/failbot_test.rb
+++ b/test/hubstep/failbot_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "hubstep/failbot"
+require "rack"
+
+module HubStep
+  class FailbotTest < Minitest::Test
+    def test_includes_request_body_in_needles
+      stub_request(:post, "http://example.com:9876/api/v0/reports").to_return(status: 400)
+
+      tracer = new_tracer
+      tracer.span("foo") { }
+      tracer.flush
+
+      report = Failbot.backend.reports.first
+      assert_kind_of String, report["request_body"]
+      refute_empty report["request_body"]
+    end
+
+    def new_tracer
+      transport = LightStep::Transport::HTTPJSON.new(
+        host: "example.com",
+        port: 9876,
+        encryption: LightStep::Transport::HTTPJSON::ENCRYPTION_NONE,
+        access_token: "12345"
+      )
+      tracer = Tracer.new(transport: transport)
+      tracer.enabled = true
+      tracer
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,8 @@ require "hubstep"
 
 require "pry-byebug"
 require "minitest/autorun"
+require "webmock/minitest"
+
+require "failbot"
+ENV["FAILBOT_BACKEND"] ||= "memory"
+Failbot.setup(ENV, app: "hubstep-test")


### PR DESCRIPTION
This is useful when the request fails due to a malformed body.