### PR TITLE
Omit URLs from Rack::Middleware spans by default

### DIFF
--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -24,7 +24,7 @@ module HubStep
       #             returns true, the tracer will be enabled for the duration
       #             of the request. If the Proc returns false, the tracer will
       #             be disabled for the duration of the request.
-      def initialize(app, tracer, enable_if)
+      def initialize(app, tracer:, enable_if:)
         @app = app
         @tracer = tracer
         @enable_if = enable_if

--- a/test/hubstep/rack/middleware_test.rb
+++ b/test/hubstep/rack/middleware_test.rb
@@ -32,7 +32,7 @@ module HubStep
 
       def test_requires_an_enabled_proc
         app = ::Rack::Builder.new do
-          use HubStep::Rack::Middleware, HubStep::Tracer.new
+          use HubStep::Rack::Middleware, tracer: HubStep::Tracer.new
           run ->(_env) { [200, {}, "<html>"] }
         end
         assert_raises ArgumentError do
@@ -144,8 +144,10 @@ module HubStep
       def app
         test_instance = self
         @app ||= ::Rack::Builder.new do
-          use HubStep::Rack::Middleware, test_instance.tracer, test_instance.enabled_proc
-          run ->(env) { test_instance.request_proc.call(env) }
+          use HubStep::Rack::Middleware,
+              tracer: test_instance.tracer,
+              enable_if: test_instance.enabled_proc
+          run test_instance.request_proc
         end
       end
     end


### PR DESCRIPTION
URLs can contain sensitive information, so by default they are omitted from spans. They can be included by specifying `include_urls: true` when configuring Rack::Middleware.

/cc @jnunemaker 