### PR TITLE
Force single Failbot app

### DIFF
--- a/lib/hubstep/failbot.rb
+++ b/lib/hubstep/failbot.rb
@@ -35,7 +35,7 @@ module LightStep
 
           nil
         ensure
-          ::Failbot.report!($ERROR_INFO) if $ERROR_INFO
+          ::Failbot.report!($ERROR_INFO, app: "lightstep") if $ERROR_INFO
           ::Failbot.pop
         end
 
@@ -43,7 +43,11 @@ module LightStep
           return unless res.is_a?(Net::HTTPClientError) || res.is_a?(Net::HTTPServerError)
           exception = HTTPError.new("#{res.code} #{res.message}")
           exception.set_backtrace(caller)
-          ::Failbot.report!(exception, response_body: res.body, response_uri: res.uri)
+          ::Failbot.report!(exception, {
+            app: "lightstep",
+            response_body: res.body,
+            response_uri: res.uri,
+          })
         end
       end
 

--- a/lib/hubstep/failbot.rb
+++ b/lib/hubstep/failbot.rb
@@ -43,11 +43,9 @@ module LightStep
           return unless res.is_a?(Net::HTTPClientError) || res.is_a?(Net::HTTPServerError)
           exception = HTTPError.new("#{res.code} #{res.message}")
           exception.set_backtrace(caller)
-          ::Failbot.report!(exception, {
-            app: "lightstep",
-            response_body: res.body,
-            response_uri: res.uri,
-          })
+          ::Failbot.report!(exception, app: "lightstep",
+                                       response_body: res.body,
+                                       response_uri: res.uri)
         end
       end
 

--- a/test/hubstep/failbot_test.rb
+++ b/test/hubstep/failbot_test.rb
@@ -10,7 +10,7 @@ module HubStep
       Failbot.backend = Failbot::MemoryBackend.new
     end
 
-    def test_reports_http_client_errors_to_failbot
+    def test_reports_http_client_errors_to_failbot # rubocop:disable Metrics/AbcSize
       stub_request(:post, "http://example.com:9876/api/v0/reports").to_return(status: 400)
 
       tracer = new_tracer
@@ -26,10 +26,10 @@ module HubStep
       refute_empty report["response_uri"]
       assert_equal "lightstep", report["app"]
       assert_equal "LightStep::Transport::HTTPJSON::Failbot::HTTPError",
-        report["class"]
+                   report["class"]
     end
 
-    def test_reports_http_server_errors_to_failbot
+    def test_reports_http_server_errors_to_failbot # rubocop:disable Metrics/AbcSize
       stub_request(:post, "http://example.com:9876/api/v0/reports").to_return(status: 500)
 
       tracer = new_tracer
@@ -45,11 +45,12 @@ module HubStep
       refute_empty report["response_uri"]
       assert_equal "lightstep", report["app"]
       assert_equal "LightStep::Transport::HTTPJSON::Failbot::HTTPError",
-        report["class"]
+                   report["class"]
     end
 
-    def test_reports_exceptions_to_failbot
-      stub_request(:post, "http://example.com:9876/api/v0/reports").to_raise(Errno::ECONNREFUSED.new)
+    def test_reports_exceptions_to_failbot # rubocop:disable Metrics/AbcSize
+      stub_request(:post, "http://example.com:9876/api/v0/reports")
+        .to_raise(Errno::ECONNREFUSED.new)
 
       tracer = new_tracer
       tracer.span("foo") { }

--- a/test/hubstep/failbot_test.rb
+++ b/test/hubstep/failbot_test.rb
@@ -6,16 +6,60 @@ require "rack"
 
 module HubStep
   class FailbotTest < Minitest::Test
-    def test_includes_request_body_in_needles
+    def setup
+      Failbot.backend = Failbot::MemoryBackend.new
+    end
+
+    def test_reports_http_client_errors_to_failbot
       stub_request(:post, "http://example.com:9876/api/v0/reports").to_return(status: 400)
 
       tracer = new_tracer
       tracer.span("foo") { }
       tracer.flush
 
-      report = Failbot.backend.reports.first
+      report = Failbot.backend.reports.last
       assert_kind_of String, report["request_body"]
       refute_empty report["request_body"]
+      assert_kind_of String, report["response_body"]
+      refute_empty report["response_body"]
+      assert_kind_of String, report["response_uri"]
+      refute_empty report["response_uri"]
+      assert_equal "lightstep", report["app"]
+      assert_equal "LightStep::Transport::HTTPJSON::Failbot::HTTPError",
+        report["class"]
+    end
+
+    def test_reports_http_server_errors_to_failbot
+      stub_request(:post, "http://example.com:9876/api/v0/reports").to_return(status: 500)
+
+      tracer = new_tracer
+      tracer.span("foo") { }
+      tracer.flush
+
+      report = Failbot.backend.reports.last
+      assert_kind_of String, report["request_body"]
+      refute_empty report["request_body"]
+      assert_kind_of String, report["response_body"]
+      refute_empty report["response_body"]
+      assert_kind_of String, report["response_uri"]
+      refute_empty report["response_uri"]
+      assert_equal "lightstep", report["app"]
+      assert_equal "LightStep::Transport::HTTPJSON::Failbot::HTTPError",
+        report["class"]
+    end
+
+    def test_reports_exceptions_to_failbot
+      stub_request(:post, "http://example.com:9876/api/v0/reports").to_raise(Errno::ECONNREFUSED.new)
+
+      tracer = new_tracer
+      tracer.span("foo") { }
+      tracer.flush
+
+      report = Failbot.backend.reports.last
+      assert_kind_of String, report["request_body"]
+      refute_empty report["request_body"]
+      assert_equal "lightstep", report["app"]
+      assert_equal "Errno::ECONNREFUSED", report["class"]
     end
 
     def new_tracer


### PR DESCRIPTION
In order to avoid these non-user facing needles from going to the app hubstep is being used in (which could trigger alerts/pages with no action to take), this PR forces all lightstep needles to a single app. We can then monitor that app however we see fit.

cc @github/high-availability for review
fyi @bbasata