### PR TITLE
Set verbosity with an environment variable

### DIFF
--- a/lib/hubstep/tracer.rb
+++ b/lib/hubstep/tracer.rb
@@ -120,12 +120,14 @@ module HubStep
       host = ENV["LIGHTSTEP_COLLECTOR_HOST"]
       port = ENV["LIGHTSTEP_COLLECTOR_PORT"]
       encryption = ENV["LIGHTSTEP_COLLECTOR_ENCRYPTION"]
+      verbosity = Integer(ENV.fetch("LIGHTSTEP_TRANSPORT_VERBOSITY", 0))
       access_token = ENV["LIGHTSTEP_ACCESS_TOKEN"]
 
       if host && port && encryption && access_token
         LightStep::Transport::HTTPJSON.new(host: host,
                                            port: port.to_i,
                                            encryption: encryption,
+                                           verbose: verbosity,
                                            access_token: access_token)
       else
         LightStep::Transport::Nil.new


### PR DESCRIPTION
To help with debugging, this change sets [the verbosity of the HTTPJSON transport](https://github.com/lightstep/lightstep-tracer-ruby/blob/aaa50b4b4963bf5e95386a530baed4b37b163670/lib/lightstep/transport/http_json.rb#L27) from the `LIGHTSTEP_TRANSPORT_VERBOSITY` environment variable.