### PR TITLE
Implement Tracer.verbose and detail span param

### DIFF
--- a/lib/hubstep/tracer.rb
+++ b/lib/hubstep/tracer.rb
@@ -15,7 +15,7 @@ module HubStep
     # tags         - Hash of tags to assign to the tracer. These will be
     #                associated with every span the tracer creates.
     # transport    - instance of a LightStep::Transport::Base subclass
-    # verbose      - Whether or not to emit detail spans, default true
+    # verbose      - Whether or not to emit verbose spans, default true
     def initialize(transport: default_transport, tags: {}, verbose: true)
       @verbose = verbose
 
@@ -62,8 +62,8 @@ module HubStep
       span || InertSpan.instance
     end
 
-    def should_emit?(detail)
-      @verbose || !detail
+    def should_emit?(verbose)
+      @verbose || !verbose
     end
 
     # Record a span representing the execution of the given block
@@ -74,14 +74,14 @@ module HubStep
     # finish         - Boolean indicating whether to "finish" (i.e., record the
     #                  span's end time and submit it to the collector).
     #                  Defaults to true.
-    # detail         - Boolean indicating this is a ancilary span, only
+    # verbose        - Boolean indicating this is a ancilary span, only
     #                  emitted when the tracer has verbose enabled, default
     #                  false
     #
     # Yields a LightStep::Span or InertSpan to the block. Returns the block's
     # return value.
-    def span(operation_name, start_time: nil, tags: nil, finish: true, detail: false)
-      unless enabled? && should_emit?(detail)
+    def span(operation_name, start_time: nil, tags: nil, finish: true, verbose: false)
+      unless enabled? && should_emit?(verbose)
         return yield InertSpan.instance
       end
 

--- a/lib/hubstep/tracer.rb
+++ b/lib/hubstep/tracer.rb
@@ -15,7 +15,10 @@ module HubStep
     # tags         - Hash of tags to assign to the tracer. These will be
     #                associated with every span the tracer creates.
     # transport    - instance of a LightStep::Transport::Base subclass
-    def initialize(transport: default_transport, tags: {})
+    # verbose      - Whether or not to emit detail spans, default true
+    def initialize(transport: default_transport, tags: {}, verbose: true)
+      @verbose = verbose
+
       name = HubStep.server_metadata.values_at("app", "role").join("-")
 
       default_tags = {
@@ -59,6 +62,10 @@ module HubStep
       span || InertSpan.instance
     end
 
+    def should_emit?(detail)
+      @verbose || !detail
+    end
+
     # Record a span representing the execution of the given block
     #
     # operation_name - short human-readable String identifying the work done by the span
@@ -67,11 +74,14 @@ module HubStep
     # finish         - Boolean indicating whether to "finish" (i.e., record the
     #                  span's end time and submit it to the collector).
     #                  Defaults to true.
+    # detail         - Boolean indicating this is a ancilary span, only
+    #                  emitted when the tracer has verbose enabled, default
+    #                  false
     #
     # Yields a LightStep::Span or InertSpan to the block. Returns the block's
     # return value.
-    def span(operation_name, start_time: nil, tags: nil, finish: true)
-      unless enabled?
+    def span(operation_name, start_time: nil, tags: nil, finish: true, detail: false)
+      unless enabled? && should_emit?(detail)
         return yield InertSpan.instance
       end
 

--- a/test/hubstep/tracer_test.rb
+++ b/test/hubstep/tracer_test.rb
@@ -203,5 +203,22 @@ module HubStep
 
       assert_equal expected, custom_attrs.sort_by { |a| a[:Key] }
     end
+
+    def test_verbosity_false
+      tracer = HubStep::Tracer.new(verbose: false)
+      tracer.enabled = true
+
+      # default level emits (we get a real span)
+      tracer.span("foo") do |foo|
+        assert_instance_of LightStep::Span, foo
+        assert_equal foo, tracer.bottom_span
+      end
+
+      # detail true does not emit
+      tracer.span("baz", detail: true) do |baz|
+        assert_equal HubStep::Tracer::InertSpan.instance, baz
+        assert_equal baz, tracer.bottom_span
+      end
+    end
   end
 end

--- a/test/hubstep/tracer_test.rb
+++ b/test/hubstep/tracer_test.rb
@@ -214,8 +214,8 @@ module HubStep
         assert_equal foo, tracer.bottom_span
       end
 
-      # detail true does not emit
-      tracer.span("baz", detail: true) do |baz|
+      # verbose true does not emit
+      tracer.span("baz", verbose: true) do |baz|
         assert_equal HubStep::Tracer::InertSpan.instance, baz
         assert_equal baz, tracer.bottom_span
       end


### PR DESCRIPTION
No change to default behavior, but this will allow applications with
extremely large numbers of traces to optionally manage the volume being
emitted.

This is a simplified and updated version of https://github.com/github/hubstep/pull/28. Rather than a complex verbosity level it's just a boolean on/off yes/no.

/cc @janester who looked at this previously 
/cc @rhettg who's probably interested based on a previous discussion