### PR TITLE
Update Faraday Middleware to optionally send `http.url`

### DIFF
--- a/test/hubstep/faraday/middleware_test.rb
+++ b/test/hubstep/faraday/middleware_test.rb
@@ -21,8 +21,8 @@ module HubStep
       end
 
       def test_traces_requests
-        @stubs.get("/foo") { [202, {}, "bar"] }
-        @faraday.get("/foo")
+        @stubs.get("http://user:password@test.com/foo") { [202, {}, "bar"] }
+        @faraday.get("http://user:password@test.com/foo")
         @stubs.verify_stubbed_calls
         @tracer.flush
 
@@ -30,7 +30,7 @@ module HubStep
         assert_equal "Faraday GET", span[:span_name]
         tags = [
           { Key: "component", Value: "faraday" },
-          { Key: "http.domain", Value: "" },
+          { Key: "http.domain", Value: "test.com" },
           { Key: "http.method", Value: "GET" },
           { Key: "http.status_code", Value: "202" },
         ]
@@ -38,9 +38,9 @@ module HubStep
       end
 
       def test_traces_requests_that_raise # rubocop:disable Metrics/MethodLength
-        @stubs.get("/foo") { raise ::Faraday::Error::TimeoutError, "request timed out" }
+        @stubs.get("http://user:password@test.com/foo") { raise ::Faraday::Error::TimeoutError, "request timed out" }
         assert_raises ::Faraday::Error::TimeoutError do
-          @faraday.get("/foo")
+          @faraday.get("http://user:password@test.com/foo")
         end
         @stubs.verify_stubbed_calls
         @tracer.flush
@@ -52,7 +52,7 @@ module HubStep
           { Key: "error", Value: "true" },
           { Key: "error.class", Value: "Faraday::TimeoutError" },
           { Key: "error.message", Value: "request timed out" },
-          { Key: "http.domain", Value: "" },
+          { Key: "http.domain", Value: "test.com" },
           { Key: "http.method", Value: "GET" },
         ]
         assert_equal tags, span[:attributes].sort_by { |a| a[:Key] }
@@ -64,8 +64,8 @@ module HubStep
           b.adapter(:test, @stubs)
         end
 
-        @stubs.get("/foo") { [202, {}, "bar"] }
-        faraday.get("/foo")
+        @stubs.get("http://user:password@test.com/foo") { [202, {}, "bar"] }
+        faraday.get("http://user:password@test.com/foo")
 
         @stubs.verify_stubbed_calls
         @tracer.flush
@@ -74,10 +74,10 @@ module HubStep
         assert_equal "Faraday GET", span[:span_name]
         tags = [
           { Key: "component", Value: "faraday" },
-          { Key: "http.domain", Value: "" },
+          { Key: "http.domain", Value: "test.com" },
           { Key: "http.method", Value: "GET" },
           { Key: "http.status_code", Value: "202" },
-          { Key: "http.url", Value: "http:/foo" },
+          { Key: "http.url", Value: "http://user:password@test.com/foo" },
         ]
         assert_equal tags, span[:attributes].sort_by { |a| a[:Key] }
       end

--- a/test/hubstep/faraday/middleware_test.rb
+++ b/test/hubstep/faraday/middleware_test.rb
@@ -30,6 +30,7 @@ module HubStep
         assert_equal "Faraday GET", span[:span_name]
         tags = [
           { Key: "component", Value: "faraday" },
+          { Key: "http.domain", Value: "" },
           { Key: "http.method", Value: "GET" },
           { Key: "http.status_code", Value: "202" },
           { Key: "http.url", Value: "http:/foo" },
@@ -52,6 +53,7 @@ module HubStep
           { Key: "error", Value: "true" },
           { Key: "error.class", Value: "Faraday::TimeoutError" },
           { Key: "error.message", Value: "request timed out" },
+          { Key: "http.domain", Value: "" },
           { Key: "http.method", Value: "GET" },
           { Key: "http.url", Value: "http:/foo" },
         ]

--- a/test/hubstep/faraday/middleware_test.rb
+++ b/test/hubstep/faraday/middleware_test.rb
@@ -38,7 +38,10 @@ module HubStep
       end
 
       def test_traces_requests_that_raise # rubocop:disable Metrics/MethodLength
-        @stubs.get("http://user:password@test.com/foo") { raise ::Faraday::Error::TimeoutError, "request timed out" }
+        @stubs.get("http://user:password@test.com/foo") do
+          raise ::Faraday::Error::TimeoutError, "request timed out"
+        end
+
         assert_raises ::Faraday::Error::TimeoutError do
           @faraday.get("http://user:password@test.com/foo")
         end


### PR DESCRIPTION
## Context

Fixes https://github.com/github/hookshot/issues/707

We don't want to send sensitive data to lightstep, but sometimes the urls of faraday requests contain sensitive information. We want to able to disable the sending of those urls. 

This also adds an `http.domain` tag, which will at least give us the domain of the request even if the url needs to be scrubbed.

## This Change

- updates the `HubStep::Faraday::Middleware` to take options which only includes a `record_url` option right now
- uses that option to disable sending the `http.url` tag. It defaults to `true`
- adds a `http.domain` tag that is parsed from the url
