### PR TITLE
Rescue from url parsing errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 15
 
+Metrics/AbcSize:
+  Max: 17
+
 Style/DoubleNegation:
   Enabled: false
 

--- a/lib/hubstep/faraday/middleware.rb
+++ b/lib/hubstep/faraday/middleware.rb
@@ -13,9 +13,25 @@ module HubStep
     #   b.adapter(:typhoeus)
     # end
     class Middleware < ::Faraday::Middleware
-      def self.uri_parser(parser = nil)
-        @uri_parser ||= URI
+      class << self
+        # Set a URI parser.
+        #
+        # parser       - An object that responds to `parse`
+        #
+        def uri_parser=(parser)
+          if parser == :default
+            parser = URI
+          end
+          @uri_parser = parser
+        end
+
+        # Get the URI parser.
+        attr_reader :uri_parser
       end
+
+      # Default the uri_parser
+      self.uri_parser = :default
+
       # Create a Middleware
       #
       # tracer    - a HubStep::Tracer instance

--- a/lib/hubstep/faraday/middleware.rb
+++ b/lib/hubstep/faraday/middleware.rb
@@ -13,6 +13,9 @@ module HubStep
     #   b.adapter(:typhoeus)
     # end
     class Middleware < ::Faraday::Middleware
+      def self.uri_parser(parser = nil)
+        @uri_parser ||= URI
+      end
       # Create a Middleware
       #
       # tracer    - a HubStep::Tracer instance
@@ -56,8 +59,15 @@ module HubStep
         url = request_env[:url]
         span.set_tag("http.url", url) if @include_urls
 
-        uri = URI.parse(url.to_s)
-        span.set_tag("http.domain", uri.host)
+        begin
+          uri = self.class.uri_parser.parse(url.to_s)
+          domain = uri.host
+        rescue => e
+          HubStep.instrumenter.instrument("hubstep.faraday.middleware.error", error: e)
+          domain = nil
+        end
+
+        span.set_tag("http.domain", domain)
       end
 
       def record_response(span, response_env)

--- a/test/hubstep/faraday/middleware_test.rb
+++ b/test/hubstep/faraday/middleware_test.rb
@@ -20,6 +20,17 @@ module HubStep
         end
       end
 
+      def test_can_configure_the_uri_parser
+        assert_equal URI, HubStep::Faraday::Middleware.uri_parser
+
+        HubStep::Faraday::Middleware.uri_parser = "test"
+
+        assert_equal "test", HubStep::Faraday::Middleware.uri_parser
+
+        # reset to the default
+        HubStep::Faraday::Middleware.uri_parser = :default
+      end
+
       def test_traces_requests
         @stubs.get("http://user:password@test.com/foo") { [202, {}, "bar"] }
         @faraday.get("http://user:password@test.com/foo")


### PR DESCRIPTION
## Context

We are getting a lot of `URI::InvalidURIError` errors but we don't really want the tracing to raise any. This adds a rescue for the the errors. It also allows us to configure a URI parser on the middleware in order to allow us to us `Addressable::URI` instead of `URI` when it's available. 

## This Change

- getter and setter for `uri_parser`
- rescue for parsing the url
