### PR TITLE
upgrade to lightstep 0.11.2

### DIFF
--- a/hubstep.gemspec
+++ b/hubstep.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "lightstep", "~> 0.10.0"
+  # We must pin to exact versions due to monkey patching
+  spec.add_dependency "lightstep", "0.11.2"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/hubstep/transport/http_json.rb
+++ b/lib/hubstep/transport/http_json.rb
@@ -3,7 +3,7 @@
 require "English"
 require "net/http"
 
-unless LightStep::VERSION == '0.10.9'
+unless LightStep::VERSION == '0.11.2'
   raise <<-MSG
     This monkey patch needs to be reviewed for LightStep versions other than 0.10.9.
     To review, diff the changes between the `LightStep::Transport::HTTPJSON#report`


### PR DESCRIPTION
Two new releases for https://github.com/lightstep/lightstep-tracer-ruby came out just days after we pinned this one.

I reviewed our monkey patch and it didn't change.