### PR TITLE
add the error:true tag to spans with error status codes

### DIFF
--- a/lib/hubstep/faraday/middleware.rb
+++ b/lib/hubstep/faraday/middleware.rb
@@ -89,9 +89,8 @@ module HubStep
         status = response_env[:status]
         span.set_tag("http.status_code", status)
 
-        if status.to_i >= 400
-          span.set_tag("error", true)
-        end
+        return if status.to_i < 400
+        span.set_tag("error", true)
       end
 
       def record_exception(span, exception)

--- a/lib/hubstep/faraday/middleware.rb
+++ b/lib/hubstep/faraday/middleware.rb
@@ -89,7 +89,7 @@ module HubStep
         status = response_env[:status]
         span.set_tag("http.status_code", status)
 
-        return if status.to_i < 400
+        return if status.to_i < 500
         span.set_tag("error", true)
       end
 

--- a/lib/hubstep/faraday/middleware.rb
+++ b/lib/hubstep/faraday/middleware.rb
@@ -86,7 +86,12 @@ module HubStep
       end
 
       def record_response(span, response_env)
-        span.set_tag("http.status_code", response_env[:status])
+        status = response_env[:status]
+        span.set_tag("http.status_code", status)
+
+        if status.to_i >= 400
+          span.set_tag("error", true)
+        end
       end
 
       def record_exception(span, exception)

--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -67,6 +67,10 @@ module HubStep
 
       def record_response(span, status, _headers, _body)
         span.set_tag("http.status_code", status)
+
+        if status.to_i >= 400
+          span.set_tag("error", true)
+        end
       end
 
       def tags(request)

--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -67,7 +67,7 @@ module HubStep
 
       def record_response(span, status, _headers, _body)
         span.set_tag("http.status_code", status)
-        return if status.to_i < 400
+        return if status.to_i < 500
         span.set_tag("error", true)
       end
 

--- a/lib/hubstep/rack/middleware.rb
+++ b/lib/hubstep/rack/middleware.rb
@@ -67,10 +67,8 @@ module HubStep
 
       def record_response(span, status, _headers, _body)
         span.set_tag("http.status_code", status)
-
-        if status.to_i >= 400
-          span.set_tag("error", true)
-        end
+        return if status.to_i < 400
+        span.set_tag("error", true)
       end
 
       def tags(request)

--- a/test/hubstep/faraday/middleware_test.rb
+++ b/test/hubstep/faraday/middleware_test.rb
@@ -55,7 +55,7 @@ module HubStep
         @tracer.flush
 
         span = @reports.dig(0, :span_records, 0)
-        assert_includes(span[:attributes], { Key: "error", Value: "true" })
+        assert_includes(span[:attributes], Key: "error", Value: "true")
       end
 
       def test_traces_requests_that_raise

--- a/test/hubstep/faraday/middleware_test.rb
+++ b/test/hubstep/faraday/middleware_test.rb
@@ -48,6 +48,16 @@ module HubStep
         assert_equal tags, span[:attributes].sort_by { |a| a[:Key] }
       end
 
+      def test_adds_error_tag_for_error_status_codes
+        @stubs.get("http://user:password@test.com/foo") { [404, {}, "bar"] }
+        @faraday.get("http://user:password@test.com/foo")
+        @stubs.verify_stubbed_calls
+        @tracer.flush
+
+        span = @reports.dig(0, :span_records, 0)
+        assert_includes(span[:attributes], { Key: "error", Value: "true" })
+      end
+
       def test_traces_requests_that_raise
         @stubs.get("http://user:password@test.com/foo") do
           raise ::Faraday::Error::TimeoutError, "request timed out"

--- a/test/hubstep/faraday/middleware_test.rb
+++ b/test/hubstep/faraday/middleware_test.rb
@@ -49,7 +49,7 @@ module HubStep
       end
 
       def test_adds_error_tag_for_error_status_codes
-        @stubs.get("http://user:password@test.com/foo") { [404, {}, "bar"] }
+        @stubs.get("http://user:password@test.com/foo") { [500, {}, "bar"] }
         @faraday.get("http://user:password@test.com/foo")
         @stubs.verify_stubbed_calls
         @tracer.flush

--- a/test/hubstep/rack/middleware_test.rb
+++ b/test/hubstep/rack/middleware_test.rb
@@ -113,6 +113,11 @@ module HubStep
         @status_code = 404
         get "/foo"
         assert_equal "404", span.tags["http.status_code"]
+        refute span.tags["error"]
+
+        @status_code = 500
+        get "/foo"
+        assert_equal "500", span.tags["http.status_code"]
         assert span.tags["error"]
       end
 

--- a/test/hubstep/rack/middleware_test.rb
+++ b/test/hubstep/rack/middleware_test.rb
@@ -108,9 +108,12 @@ module HubStep
         @status_code = 200
         get "/foo"
         assert_equal "200", span.tags["http.status_code"]
+        refute span.tags["error"]
+
         @status_code = 404
         get "/foo"
         assert_equal "404", span.tags["http.status_code"]
+        assert span.tags["error"]
       end
 
       def test_wraps_request_in_span


### PR DESCRIPTION
## Context

We add the `error:true` tag to requests that have error status codes in other services like GLB, but haven't done the same for the app requests recorded via hubstep. This updates both middlewares to include that `error:true` tag when the status code is equal to or higher than 400.

## This Change

- update rack middleware to add `error:true` tag when code is higher than 400
- tests for rack middleware change
- update faraday middleware to add `error:true` tag when code is higher than 400
- tests for faraday middleware change

---
EDIT: I've actually changed it to only add the tag for 5xx error codes. See https://github.com/github/hubstep/pull/36#discussion_r152670071 for more info.