### PR TITLE
keep-alive, the saga continues

### DIFF
--- a/lib/hubstep/transport/http_json.rb
+++ b/lib/hubstep/transport/http_json.rb
@@ -26,10 +26,6 @@ module HubStep
       ENCRYPTION_TLS = 'tls'
       ENCRYPTION_NONE = 'none'
 
-      # Provide access to the underlying Net::HTTP object so we can do fun
-      # stuff like verify keep-alive is working.
-      attr_reader :http
-
       # Initialize the transport
       # @param host [String] host of the domain to the endpoind to push data
       # @param port [Numeric] port on which to connect

--- a/lib/hubstep/transport/http_json.rb
+++ b/lib/hubstep/transport/http_json.rb
@@ -26,6 +26,10 @@ module HubStep
       ENCRYPTION_TLS = 'tls'
       ENCRYPTION_NONE = 'none'
 
+      # Provide access to the underlying Net::HTTP object so we can do fun
+      # stuff like verify keep-alive is working.
+      attr_reader :http
+
       # Initialize the transport
       # @param host [String] host of the domain to the endpoind to push data
       # @param port [Numeric] port on which to connect
@@ -50,8 +54,9 @@ module HubStep
         # for example)
         @mutex = Mutex.new
 
-        @https = Net::HTTP.new(host, port)
-        @https.use_ssl = encryption == ENCRYPTION_TLS
+        @http = Net::HTTP.new(host, port)
+        @http.use_ssl = encryption == ENCRYPTION_TLS
+        @http.keep_alive_timeout = 5
       end
 
       def report(report)
@@ -61,7 +66,7 @@ module HubStep
 
         @mutex.synchronize do
           begin
-            res = @https.request(req)
+            res = @http.request(req)
           rescue => e
             res = e
           ensure

--- a/lib/hubstep/transport/http_json.rb
+++ b/lib/hubstep/transport/http_json.rb
@@ -65,6 +65,11 @@ module HubStep
         req = request report
 
         @mutex.synchronize do
+          # Typically, keep-alive for Net:HTTP is handled inside a start block,
+          # but that's awkward with our threading model. By starting it manually,
+          # once, the TCP connection should remain open for multiple report calls.
+          @http.start unless @http.started?
+
           begin
             res = @http.request(req)
           rescue => e

--- a/lib/hubstep/version.rb
+++ b/lib/hubstep/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HubStep
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end

--- a/lib/hubstep/version.rb
+++ b/lib/hubstep/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HubStep
-  VERSION = "2.1.2"
+  VERSION = "2.1.1"
 end


### PR DESCRIPTION
The default of 2 seconds won't work with our reporting loop.
Also, for instrumentation purposes we're going to expose our underlying
http object.

I think I'm probably going to undo this `attr_reader` part as I'm hacking away in github/github to integrate I don't think it can work 😢 

/cc @ross also for ideas on how to confirm this in production