### PR TITLE
Add delegation for Tracer#inject

### DIFF
--- a/lib/hubstep/tracer.rb
+++ b/lib/hubstep/tracer.rb
@@ -147,7 +147,7 @@ module HubStep
     #
     # Returns nil but mutates the carrier.
     def inject(span_context, format, carrier)
-      return carrier unless enabled?
+      return unless enabled?
 
       @tracer.inject(span_context, format, carrier)
     end

--- a/lib/hubstep/tracer.rb
+++ b/lib/hubstep/tracer.rb
@@ -215,7 +215,7 @@ module HubStep
       end
     end
 
-    # Mimics the interface and no-op behavior of LightStep::SpanContaxt. This
+    # Mimics the interface and no-op behavior of LightStep::SpanContext. This
     # is used when tracing is disabled.
     class InertSpanContext
       include Singleton


### PR DESCRIPTION
This PR adds delegation from `HubStep::Tracer.inject` to `LightStep::Tracer.inject` when tracing is enabled. Injection is necessary to serialize and propagate trace information between services.

cc @janester @rhettg @jnunemaker 