### PR TITLE
Support distributed tracing

### DIFF
--- a/lib/hubstep/tracer.rb
+++ b/lib/hubstep/tracer.rb
@@ -88,7 +88,7 @@ module HubStep
       end
 
       span = @tracer.start_span(operation_name,
-                                child_of: child_of || @spans.last,
+                                child_of: parent_span(child_of),
                                 start_time: start_time,
                                 tags: tags)
       @spans << span
@@ -197,6 +197,10 @@ module HubStep
       else
         @spans.delete(span)
       end
+    end
+
+    def parent_span(child_of)
+      child_of || @spans.last
     end
 
     # Mimics the interface and no-op behavior of OpenTracing::Span. This is

--- a/test/hubstep/tracer_test.rb
+++ b/test/hubstep/tracer_test.rb
@@ -241,7 +241,7 @@ module HubStep
       tracer = HubStep::Tracer.new
       carrier = {
         "ot-tracer-traceid" => "trace-1",
-        "ot-tracer-spanid" => "span-1"
+        "ot-tracer-spanid" => "span-1",
       }
 
       tracer.with_enabled(false) do


### PR DESCRIPTION
This adds a new `child_of` keyword argument to `Tracer#span` so that extracted tracing information can be injected. Using the extract method, one can get extract a `SpanContext` from a tracing carrier (typically, HTTP headers) and connect a remote service to its caller as a child. This enables better ordering of operations in the LightStep UI.